### PR TITLE
Improve README.md formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Monte-Carlo type algorithm for computing the linear response of random chaotic
 
 
 List of files and usage:
-nop.py: the main algorithm on tent map, one long orbit
-density.py: plot the density of physical measure of the tent map.
-dhT.py: the main algorithm on neural networks, many short (51 layers) orbits.
-LE.py: compute the Lypunove spectrum of the chaotic NN.
+* nop.py: the main algorithm on tent map, one long orbit
+* density.py: plot the density of physical measure of the tent map.
+* dhT.py: the main algorithm on neural networks, many short (51 layers) orbits.
+* LE.py: compute the Lypunove spectrum of the chaotic NN.


### PR DESCRIPTION
Markdown ignores new lines so that all files and descriptions were merged into a single paragraph during rendering.